### PR TITLE
Docker for redis stack only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 
 To contribute to this GitHub project, you can follow these steps:
 
-1. Fork the repository you want to contribute to by clicking the "Fork" button on the project page.
+1. Fork the repository you want to contribute to by clicking the "Fork" button on the project page. Note URL of the fork.
 
-2. Clone the repository to your local machine using the following command:
+2. Clone your forked repository to your local machine using the following command:
 
 ```
-git clone https://github.com/Torantulino/Auto-GPT
+git clone https://github.com/your_profile/Auto-GPT
 ```
 3. Create a new branch for your changes using the following command:
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Your support is greatly appreciated
 
 - [Auto-GPT: An Autonomous GPT-4 Experiment](#auto-gpt-an-autonomous-gpt-4-experiment)
     - [Demo (30/03/2023):](#demo-30032023)
-  - [💖 Help Fund Auto-GPT's Development](#-help-fund-auto-gpts-development)
   - [Table of Contents](#table-of-contents)
   - [🚀 Features](#-features)
   - [📋 Requirements](#-requirements)
@@ -40,9 +39,14 @@ Your support is greatly appreciated
   - [🗣️ Speech Mode](#️-speech-mode)
   - [🔍 Google API Keys Configuration](#-google-api-keys-configuration)
     - [Setting up environment variables](#setting-up-environment-variables)
+  - [Redis Setup](#redis-setup)
+  - [Redis Stack Setup with Docker Composer on Linux](#redis-stack-setup-with-docker-composer-on-linux)
+  - [🌲 Pinecone API Key Setup](#-pinecone-api-key-setup)
+    - [Setting up environment variables](#setting-up-environment-variables-1)
+  - [View Memory Usage](#view-memory-usage)
   - [💀 Continuous Mode ⚠️](#-continuous-mode-️)
   - [GPT3.5 ONLY Mode](#gpt35-only-mode)
-  - [🖼 Image Generation](#image-generation)
+  - [🖼 Image Generation](#-image-generation)
   - [⚠️ Limitations](#️-limitations)
   - [🛡 Disclaimer](#-disclaimer)
   - [🐦 Connect with Us on Twitter](#-connect-with-us-on-twitter)
@@ -143,7 +147,7 @@ export CUSTOM_SEARCH_ENGINE_ID="YOUR_CUSTOM_SEARCH_ENGINE_ID"
 
 ## Redis Setup
 
-Install docker desktop.
+Install Docker Desktop.
 
 Run:
 ```
@@ -174,6 +178,20 @@ You can specify the memory index for redis using the following:
 ````
 MEMORY_INDEX=whatever
 ````
+## Redis Stack Setup with Docker Composer on Linux
+
+Steps:
+1. Improve security by setting up a Redis password in .env.
+```
+MEMORY_BACKEND=redis
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=secret
+```
+2. Run `./start_redis_docker.sh` and check with `docker ps` the presence of "redis-stack" under the NAMES column.
+3. Launch Auto-GPT and check for "Using memory of type: RedisMemory" at runtime.
+4. Start a query and then access [RedisInsight](http://localhost:8001/) using the defined password. Visualize data in real time, including performance statistics.
+
 
 ## 🌲 Pinecone API Key Setup
 

--- a/docker_redis.yml
+++ b/docker_redis.yml
@@ -1,0 +1,19 @@
+version: '3.9'
+
+services:
+  redis:
+    image: redis/redis-stack:latest # use redis/redis-stack-server:latest for Production deployment without RedisInsight
+    container_name: redis-stack
+    ports:
+      - "6379:6379"
+      - '8001:8001'
+    environment: 
+      REDIS_ARGS: --requirepass $REDIS_PASSWORD # value taken from REDIS_PASSWORD=secret in .env
+    volumes:
+      - redis-data:/data
+
+volumes:
+  redis-data:
+    driver: local
+
+# You can use RedisInsight by pointing your browser to http://localhost:8001.

--- a/start_redis_docker.sh
+++ b/start_redis_docker.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+printf ">>> \033[32mRunning\033[0m 'docker-compose -f docker_redis.yml up -d' \n"
+printf ">>> \033[31mStop\033[0m the Redis-Stack docker container with 'docker stop redis-stack' \n"
+sleep 2
+docker-compose -f docker_redis.yml up -d


### PR DESCRIPTION
Background

The aim of this PR is to make the use of Redis Stack beginner friendly and help developers get consistent results.
Developers and curious people can access RedisInsight at http://localhost:8001/ to see the interaction between Auto-GPT and Redis caching engine.
Changes

Made it easier to use Redis by providing the steps in the updated documentation.
Consistent build, configuration and testing using a docker-compose.yml type of configuration.
Easy start of the Docker container by using a shell script.
Easier debugging and tracing by using Redis Stack with built-in RedisInsight for development cycles.
Better security by enabling an access password for "Production Ready".

    Updated README.md with a Docker for Linux.
    Added the Docker Compose file as docker_redis.yml
    Added a shell script to make it easy to start the container with start_redis_docker.sh

Test Plan

Configuration validation with docker-compose -f docker_redis.yml config on:

    Fedora Linux 37 with Docker version 23.0.3, build 3e7cbfd and Docker Compose version v2.17.2.
    Third party confirmation of correct build on Windows 11 with Docker Desktop 4.18.0 and Docker Compose version v2.17.2.
    Multiple build cycles with docker system prune -a to eliminate any image conflicts potential

Successful configuration and built of a Docker Stack image and confirmed:

    .env has the correct Redis configuration
    Running Auto-GPT reports “Using memory of type: RedisMemory”
    Checking http://localhost:8001/redis-stack/browser and confirming the CPU, Total Memory, Total Keys and Connected Clients all report positive non-zero values.

https://github.com/Torantulino/Auto-GPT/pull/605#issue-1659931836